### PR TITLE
Adding a comparison between dashboarding on Databricks and Tableau/PowerBI

### DIFF
--- a/UserGuide/Databricks/Dashboarding-Tool-Comparison.md
+++ b/UserGuide/Databricks/Dashboarding-Tool-Comparison.md
@@ -1,0 +1,63 @@
+# Dashboards on Databricks Compared to Other Tools
+
+Databricks, PowerBI, and Tableau are all powerful tools used for data analysis and visualization, but they have different focuses and capabilities, particularly when it comes to dashboarding. This article will compare the dashboarding capabilities of Databricks on the FSDH, PowerBI, and Tableau.
+
+## Databricks
+
+**Focus:** Primarily a data analytics platform with a focus on big data processing, machine learning, and collaborative data science.
+
+**Dashboarding:**
+
+* Integration with Notebooks: Dashboards are created from notebooks, which can contain a mix of code, visualizations, and narrative text.
+* Real-time Data: Because of its Spark-based architecture, Databricks can handle real-time data processing and display live data on dashboards.
+* Collaboration: Allows for collaborative work on notebooks, which can then be shared as dashboards within a team or organization.
+* Customizability: Limited compared to dedicated BI tools; however, it supports various visualization libraries that can be used within notebooks (e.g., Matplotlib or Plotly).
+* Interactivity: Dashboards can be interactive to an extent, but the interactivity is typically more limited than in PowerBI or Tableau.
+
+## PowerBI
+
+**Focus:** A business analytics service by Microsoft that provides non-technical business users with tools for aggregating, analyzing, visualizing, and sharing data.
+
+**Dashboarding:**
+
+* Ease of Use: Known for its user-friendly interface and drag-and-drop features that make it easy to create dashboards.
+* Data Connectivity: Offers robust data connectivity options to various data sources and has strong integration with other Microsoft products.
+* Interactivity: Highly interactive dashboards with drill-down capabilities and extensive filtering options.
+* Real-time Data: Supports real-time dashboards with streaming datasets.
+* Custom Visuals: A large library of visuals and the ability to import custom visuals from the marketplace or create your own.
+
+## Tableau
+
+**Focus:** A leading data visualization tool that is designed to help users create interactive and shareable dashboards.
+
+**Dashboarding:**
+
+* Visualization Capabilities: Known for its strong data visualization capabilities with a wide array of charts and graphs.
+* User Experience: Intuitive and user-friendly interface that supports drag-and-drop functionalities.
+* Data Handling: Can handle large volumes of data and connect to various data sources.
+* Interactivity: Offers high interactivity with features like tooltips, filters, and parameters that can be used to create highly dynamic dashboards.
+* Community and Resources: Has a large and active community with a wealth of resources, templates, and forums for support.
+
+## Comparison
+
+| **Feature** | **Databricks** | **PowerBI** | **Tableau** |
+| -------------------------- | -------------------------------------- | -------------------------------------- | -------------------------------------- |
+| **Primary Focus** | Data science & big data analytics | Business intelligence & data analytics | Data visualization & business intelligence |
+| **Ease of Use** | Requires coding knowledge | User-friendly, intuitive drag-and-drop interface | User-friendly, intuitive drag-and-drop interface |
+| **Real-time Data** | Handles real-time data processing | Supports real-time dashboards | Supports real-time dashboards with some limitations |
+| **Data Connectivity** | Connects to various data sources | Extensive data connectivity, strong Microsoft integration | Wide range of data connection options |
+| **Interactivity** | Limited interactivity in dashboards | Highly interactive dashboards | Highly interactive dashboards |
+| **Visualization Libraries** | Large collection of visualizations. Supports libraries like Matplotlib or Plotly. | Large library of visuals, custom visuals can be imported | Extensive visualization options, strong in data storytelling |
+| **Collaboration** | Collaborative notebook environment | Collaboration features within Microsoft ecosystem | Collaboration features, strong community support |
+| **Customizability** | Limited compared to BI tools, customizable through code | High customizability with visuals and reports | High customizability with a focus on visual appeal |
+| **User Base** | Scientists, data engineers | Business analysts, non-technical users | Data analysts, business users |
+
+## Conclusion
+
+In summary, Databricks, PowerBI, and Tableau offer unique dashboarding capabilities tailored to different user need: 
+
+* Databricks is ideal for scientists and engineers focused on big data and collaboration, offering real-time processing within a coding environment. 
+* PowerBI caters to business analysts and non-technical users with its intuitive interface and strong Microsoft integration, enabling the creation of highly interactive dashboards with ease. 
+* Tableau is useful for users who prioritize advanced data visualization and storytelling with its user-friendly design and dynamic interactivity. 
+
+The selection among these tools depends on the user's technical proficiency, data requirements, and the desired level of dashboard interactivity and customization.

--- a/UserGuide/Databricks/Dashboarding-Tool-Comparison.md
+++ b/UserGuide/Databricks/Dashboarding-Tool-Comparison.md
@@ -12,11 +12,11 @@ Databricks, PowerBI, and Tableau are all powerful tools used for data analysis a
 * Real-time Data: Because of its Spark-based architecture, Databricks can handle real-time data processing and display live data on dashboards.
 * Collaboration: Allows for collaborative work on notebooks, which can then be shared as dashboards within a team or organization.
 * Customizability: Limited compared to dedicated BI tools; however, it supports various visualization libraries that can be used within notebooks (e.g., Matplotlib or Plotly).
-* Interactivity: Dashboards can be interactive to an extent, but the interactivity is typically more limited than in PowerBI or Tableau.
+* Interactivity: Dashboards can be interactive to an extent, but the interactivity is typically more limited than in PowerBI or Tableau. Dashboards can leverage Python Widgets for interactive inputs.
 
 ## PowerBI
 
-**Focus:** A business analytics service by Microsoft that provides non-technical business users with tools for aggregating, analyzing, visualizing, and sharing data.
+**Focus:** A business analytics service by Microsoft that provides business users with tools for aggregating, analyzing, visualizing, and sharing data.
 
 **Dashboarding:**
 
@@ -40,17 +40,18 @@ Databricks, PowerBI, and Tableau are all powerful tools used for data analysis a
 
 ## Comparison
 
-| **Feature** | **Databricks** | **PowerBI** | **Tableau** |
-| -------------------------- | -------------------------------------- | -------------------------------------- | -------------------------------------- |
-| **Primary Focus** | Data science & big data analytics | Business intelligence & data analytics | Data visualization & business intelligence |
-| **Ease of Use** | Requires coding knowledge | User-friendly, intuitive drag-and-drop interface | User-friendly, intuitive drag-and-drop interface |
-| **Real-time Data** | Handles real-time data processing | Supports real-time dashboards | Supports real-time dashboards with some limitations |
-| **Data Connectivity** | Connects to various data sources | Extensive data connectivity, strong Microsoft integration | Wide range of data connection options |
-| **Interactivity** | Limited interactivity in dashboards | Highly interactive dashboards | Highly interactive dashboards |
-| **Visualization Libraries** | Large collection of visualizations. Supports libraries like Matplotlib or Plotly. | Large library of visuals, custom visuals can be imported | Extensive visualization options, strong in data storytelling |
-| **Collaboration** | Collaborative notebook environment | Collaboration features within Microsoft ecosystem | Collaboration features, strong community support |
-| **Customizability** | Limited compared to BI tools, customizable through code | High customizability with visuals and reports | High customizability with a focus on visual appeal |
-| **User Base** | Scientists, data engineers | Business analysts, non-technical users | Data analysts, business users |
+| **Feature**                 | **Databricks**                                                                    | **PowerBI**                                               | **Tableau**                                                  |
+| --------------------------- | --------------------------------------------------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------ |
+| **Primary Focus**           | Data science & big data analytics                                                 | Business intelligence & data analytics                    | Data visualization & business intelligence                   |
+| **Ease of Use**             | Requires coding knowledge                                                         | User-friendly, intuitive drag-and-drop interface          | User-friendly, intuitive drag-and-drop interface             |
+| **Real-time Data**          | Handles real-time data processing                                                 | Supports real-time dashboards                             | Supports real-time dashboards with some limitations          |
+| **Data Connectivity**       | Connects to various data sources                                                  | Extensive data connectivity, strong Microsoft integration | Wide range of data connection options                        |
+| **Interactivity**           | Limited interactivity in dashboards                                               | Highly interactive dashboards                             | Highly interactive dashboards                                |
+| **Visualization Libraries** | Large collection of visualizations. Supports libraries like Matplotlib or Plotly. | Large library of visuals, custom visuals can be imported  | Extensive visualization options, strong in data storytelling |
+| **Collaboration**           | Collaborative notebook environment                                                | Collaboration features within Microsoft ecosystem         | Collaboration features, strong community support             |
+| **Customizability**         | Limited compared to BI tools, customizable through code                           | High customizability with visuals and reports             | High customizability with a focus on visual appeal           |
+| **Geospatial**              | Map visualization is available but limited (no layers, basic geocoding)           | Fully featured with layers and ESRI maps                  | Fully featured with layers and ESRI maps                     |
+| **User Base**               | Scientists, data engineers                                                        | Data analysts, business users                             | Data analysts, business users                                |
 
 ## Conclusion
 

--- a/UserGuide/_sidebar.md
+++ b/UserGuide/_sidebar.md
@@ -11,7 +11,6 @@
     - [Import Azure Storage](/UserGuide/Storage/Import-Azure-Storage.md)
     - [Import AWS Storage](/UserGuide/Storage/Import-AWS-Storage.md)
     - [Import Google Cloud Platform Storage](/UserGuide/Storage/Import-GCP-Storage.md)
-    - [Access your storage account in Databricks](/UserGuide/Databricks/Access-your-storage-account-in-Databricks.md)
     - [Add data UI in Databricks](https://learn.microsoft.com/en-us/azure/databricks/ingestion/add-data/)
 
   - Databricks and Python Notebooks  
@@ -26,7 +25,6 @@
 
   - Visualize My data
     - [How to build Dashboards with Databricks](/UserGuide/Databricks/Dashboarding.md)
-    - [Building Dashboards](/UserGuide/Databricks/Dashboarding.md)
     - [Compare Dashboarding Tools](/UserGuide/Databricks/Dashboarding-Tool-Comparison.md)
 
   - Connect APIs
@@ -51,7 +49,6 @@
   
   - Geospatial
     - [Digital Elevation Models (DEM) Tools and Raster Calculator](https://www.statcan.gc.ca/en/wtc/online-lectures/qgis/2020020)
-
 
 - Workspaces [](Icon:Workspaces)
   - Getting Started

--- a/UserGuide/_sidebar.md
+++ b/UserGuide/_sidebar.md
@@ -27,6 +27,7 @@
   - Visualize My data
     - [How to build Dashboards with Databricks](/UserGuide/Databricks/Dashboarding.md)
     - [Building Dashboards](/UserGuide/Databricks/Dashboarding.md)
+    - [Compare Dashboarding Tools](/UserGuide/Databricks/Dashboarding-Tool-Comparison.md)
 
   - Connect APIs
     - [How to connect Google APIs with Databricks](/UserGuide/Databricks/Connecting-Google-API.md)

--- a/filemappings.json
+++ b/filemappings.json
@@ -387,7 +387,7 @@
   {
     "Id": "ee919b9e-fb67-9b92-798a-e2a28fd93dd6",
     "En": "/UserGuide/Database/psql-databricks-comparison.md",
-    "Fr": "/fr/UserGuide/Database/Comparaison-des-banques-de-donn\u00E9es-psql.md"
+    "Fr": "/fr/UserGuide/Database/Comparaison-des-bases-de-donn\u00E9es-psql.md"
   },
   {
     "Id": "138dd3b6-021d-b4cb-d371-35573fdb93c7",

--- a/filemappings.json
+++ b/filemappings.json
@@ -387,7 +387,7 @@
   {
     "Id": "ee919b9e-fb67-9b92-798a-e2a28fd93dd6",
     "En": "/UserGuide/Database/psql-databricks-comparison.md",
-    "Fr": "/fr/UserGuide/Database/Comparaison-des-bases-de-donn\u00E9es-psql.md"
+    "Fr": "/fr/UserGuide/Database/Comparaison-des-banques-de-donn\u00E9es-psql.md"
   },
   {
     "Id": "138dd3b6-021d-b4cb-d371-35573fdb93c7",
@@ -433,6 +433,11 @@
     "Id": "9e51ec88-bf92-47ef-2fbc-f85af0a5a136",
     "En": "/UserGuide/Databricks/Connecting-Google-API.md",
     "Fr": "/fr/UserGuide/Databricks/Connexion-\u00E0-l\u0027API-Google.md"
+  },
+  {
+    "Id": "a6234420-06c3-cbf7-f6d8-380415d4b9f8",
+    "En": "/UserGuide/Databricks/Dashboarding-Tool-Comparison.md",
+    "Fr": "/fr/UserGuide/Databricks/Comparaison-des-outils-de-tableau-de-bord.md"
   },
   {
     "Id": "38ddb7c4-3617-2aa5-69bb-45b665f122b4",

--- a/fr/UserGuide/Databricks/Comparaison-des-outils-de-tableau-de-bord.md
+++ b/fr/UserGuide/Databricks/Comparaison-des-outils-de-tableau-de-bord.md
@@ -1,0 +1,64 @@
+# Les tableaux de bord sur Databricks comparés à d'autres outils
+
+Databricks, PowerBI et Tableau sont tous des outils puissants utilisés pour l'analyse et la visualisation des données, mais ils ont des objectifs et des capacités différents, en particulier en ce qui concerne les tableaux de bord. Cet article compare les capacités de Databricks sur le DHSF, PowerBI et Tableau en matière de tableaux de bord.
+
+## Databricks
+
+**L'objectif est de créer une plateforme d'analyse de données avec un accent particulier sur le traitement des données massives, l'apprentissage automatique et la science des données collaborative.
+
+**Dashboarding:**
+
+* Intégration avec les carnets de notes : Les tableaux de bord sont créés à partir de carnets de notes, qui peuvent contenir un mélange de code, de visualisations et de texte narratif.
+* Données en temps réel : Grâce à son architecture basée sur Spark, Databricks peut gérer le traitement des données en temps réel et afficher des données en direct sur des tableaux de bord.
+* Collaboration : Permet de travailler en collaboration sur des carnets de notes, qui peuvent ensuite être partagés en tant que tableaux de bord au sein d'une équipe ou d'une organisation.
+* Personnalisation : Limitée par rapport aux outils de BI spécialisés ; cependant, elle prend en charge diverses bibliothèques de visualisation qui peuvent être utilisées dans les carnets (par exemple, Matplotlib ou Plotly).
+* Interactivité : Les tableaux de bord peuvent être interactifs dans une certaine mesure, mais l'interactivité est généralement plus limitée que dans PowerBI ou Tableau. Les tableaux de bord peuvent utiliser des widgets Python pour des entrées interactives.
+
+## PowerBI
+
+**Focus:** Un service d'analyse commerciale de Microsoft qui fournit aux utilisateurs professionnels des outils d'agrégation, d'analyse, de visualisation et de partage des données.
+
+**Dashboarding:**
+
+* Facilité d'utilisation : Connu pour son interface conviviale et ses fonctions de glisser-déposer qui facilitent la création de tableaux de bord.
+* Connectivité des données : Offre de solides options de connectivité avec diverses sources de données et une forte intégration avec d'autres produits Microsoft.
+* Interactivité : Tableaux de bord hautement interactifs avec des capacités d'exploration et des options de filtrage étendues.
+* Données en temps réel : Prend en charge les tableaux de bord en temps réel avec des ensembles de données en continu.
+* Visuels personnalisés : Une vaste bibliothèque de visuels et la possibilité d'importer des visuels personnalisés du marché ou de créer les vôtres.
+
+## Tableau
+
+**Le but est d'aider les utilisateurs à créer des tableaux de bord interactifs et faciles à partager.
+
+**Dashboarding:**
+
+* Capacités de visualisation : Connu pour ses fortes capacités de visualisation de données avec un large éventail de diagrammes et de graphiques.
+* Expérience utilisateur : Interface intuitive et conviviale qui prend en charge les fonctionnalités de glisser-déposer.
+* Traitement des données : Peut traiter de grands volumes de données et se connecter à diverses sources de données.
+* Interactivité : Offre une grande interactivité grâce à des fonctionnalités telles que les infobulles, les filtres et les paramètres qui peuvent être utilisés pour créer des tableaux de bord très dynamiques.
+* Communauté et ressources : La communauté est vaste et active et propose une multitude de ressources, de modèles et de forums d'assistance.
+
+## Comparaison
+
+| **Feature** | **Databricks** | | **PowerBI** | **Tableau** |
+| --------------------------- | --------------------------------------------------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------ |
+| Vous êtes un professionnel de l'informatique, de la finance et de l'industrie, et vous avez besoin d'une assistance technique.
+| L'interface utilisateur est conviviale, intuitive et permet de glisser-déposer.
+| Les données en temps réel **Les données en temps réel** | Traite les données en temps réel | Prend en charge les tableaux de bord en temps réel | Prend en charge les tableaux de bord en temps réel avec certaines limites |
+| Connectivité des données ** Connectivité des données** | Connexion à diverses sources de données | Connectivité des données étendue, forte intégration de Microsoft | Large éventail d'options de connexion des données
+| Interactivité limitée dans les tableaux de bord | Tableaux de bord hautement interactifs | Tableaux de bord hautement interactifs | Tableaux de bord hautement interactifs | Tableaux de bord hautement interactifs
+| Bibliothèques de visualisation** | Grande collection de visualisations. Prend en charge des bibliothèques comme Matplotlib ou Plotly. | Les options de visualisation sont nombreuses et permettent de raconter des histoires à partir de données.
+| Collaboration** | Environnement de travail collaboratif | Fonctionnalités de collaboration au sein de l'écosystème Microsoft | Fonctionnalités de collaboration, soutien important de la part de la communauté
+| Les outils d'aide à la décision peuvent être personnalisés par le biais d'un code, mais la personnalisation est limitée par rapport aux outils de BI.
+| La visualisation des cartes est disponible mais limitée (pas de couches, géocodage de base).
+| Les utilisateurs sont des scientifiques, des ingénieurs de données, des analystes de données, des utilisateurs professionnels, des analystes de données et des utilisateurs professionnels.
+
+## Conclusion
+
+En résumé, Databricks, PowerBI et Tableau offrent des capacités uniques de création de tableaux de bord adaptées aux différents besoins des utilisateurs :
+
+* Databricks est idéal pour les scientifiques et les ingénieurs qui se concentrent sur le big data et la collaboration, offrant un traitement en temps réel dans un environnement de codage.
+* PowerBI s'adresse aux analystes commerciaux et aux utilisateurs non techniques grâce à son interface intuitive et à la forte intégration de Microsoft, ce qui permet de créer facilement des tableaux de bord hautement interactifs.
+* Tableau est utile pour les utilisateurs qui privilégient la visualisation avancée des données et la narration grâce à sa conception conviviale et à son interactivité dynamique.
+
+Le choix de ces outils dépend des compétences techniques de l'utilisateur, des exigences en matière de données et du niveau souhaité d'interactivité et de personnalisation du tableau de bord.

--- a/fr/UserGuide/_sidebar.md
+++ b/fr/UserGuide/_sidebar.md
@@ -25,6 +25,7 @@
 
   - Visualiser mes données
     - [Comment construire des tableaux de bord avec Databricks](/fr/UserGuide/Databricks/Tableau-de-bord.md)
+    - [Compare Dashboarding Tools](/fr/UserGuide/Databricks/Comparaison-des-outils-de-tableau-de-bord.md)
 
   - Connecter les API
     - [Comment connecter les API de Google avec Databricks](/fr/UserGuide/Databricks/Connexion-à-l'API-Google.md)
@@ -40,7 +41,7 @@
     - [Prévision des températures avec Databricks Exemple](/fr/UserGuide/Tutorials/Prévisions-SST.md)
     - [Torchvision pour l'analyse des vidéos de Dash Cam dans Databricks](/fr/UserGuide/Tutorials/Torchvision.md)
 
-  - Planifier des tâches
+  - Planification des tâches
     - [Comment planifier des tâches dans Databricks](/fr/UserGuide/Databricks/Flux-de-travail.md)
 
   - Applications Web

--- a/fr/UserGuide/_sidebar.md
+++ b/fr/UserGuide/_sidebar.md
@@ -11,7 +11,6 @@
     - [Importer Azure Storage](/fr/UserGuide/Storage/Importer-Azure-Storage.md)
     - [Importer le stockage AWS](/fr/UserGuide/Storage/Importer-le-stockage-AWS.md)
     - [Importer le stockage de Google Cloud Platform](/fr/UserGuide/Storage/Importer-le-stockage-GCP.md)
-    - [Accédez à votre compte de stockage dans Databricks](/fr/UserGuide/Databricks/Accédez-à-votre-compte-de-stockage-dans-Databricks.md)
     - [Ajouter une interface utilisateur dans Databricks](https://learn.microsoft.com/fr-ca/azure/databricks/ingestion/add-data/)
 
   - Databricks et Notebooks Python
@@ -26,7 +25,6 @@
 
   - Visualiser mes données
     - [Comment construire des tableaux de bord avec Databricks](/fr/UserGuide/Databricks/Tableau-de-bord.md)
-    - [Construire des tableaux de bord](/fr/UserGuide/Databricks/Tableau-de-bord.md)
 
   - Connecter les API
     - [Comment connecter les API de Google avec Databricks](/fr/UserGuide/Databricks/Connexion-à-l'API-Google.md)
@@ -42,7 +40,7 @@
     - [Prévision des températures avec Databricks Exemple](/fr/UserGuide/Tutorials/Prévisions-SST.md)
     - [Torchvision pour l'analyse des vidéos de Dash Cam dans Databricks](/fr/UserGuide/Tutorials/Torchvision.md)
 
-  - Emplois dans le domaine de l'ordonnancement
+  - Planifier des tâches
     - [Comment planifier des tâches dans Databricks](/fr/UserGuide/Databricks/Flux-de-travail.md)
 
   - Applications Web

--- a/fr/filenamecache.json
+++ b/fr/filenamecache.json
@@ -537,6 +537,10 @@
   },
   {
     "English": "psql-databricks-comparison.md",
-    "French": "Comparaison-des-banques-de-donn\u00E9es-psql.md"
+    "French": "Comparaison-des-bases-de-donn\u00E9es-psql.md"
+  },
+  {
+    "English": "Dashboarding-Tool-Comparison.md",
+    "French": "Comparaison-des-outils-de-tableau-de-bord.md"
   }
 ]


### PR DESCRIPTION
This PR adds UserGuide/Databricks/Dashboarding-Tool-Comparison.md to compare Databricks/Tableau/PowerBI for dashboarding.

It also corrects a few small issues with the sidebar, including duplicate links and wrong translation.