### PR TITLE
Acknowledgement for webapp added to docs

### DIFF
--- a/UserGuide/Acknowledgements/WebAppTC.md
+++ b/UserGuide/Acknowledgements/WebAppTC.md
@@ -1,0 +1,9 @@
+The following web application has been uploaded by a user onto this data platform using their own code. Please be aware that the content and functionality of this application are entirely controlled by the user who uploaded it, and the platform provider takes no responsibility for its content, accuracy, or performance.
+
+It is the sole responsibility of the user and the content creator to ensure that any material or information included in the web application complies with applicable laws, regulations, and ethical standards. The platform provider does not endorse, guarantee, or warrant the suitability, completeness, or security of the uploaded application.
+
+By accessing and using this web application, you acknowledge that the platform provider assumes no liability for any damages, losses, or injuries incurred as a result of its use or reliance on the content provided by the user. Users are advised to exercise caution and perform due diligence when interacting with the application and its content.
+
+Please note that any questions or concerns regarding the content or functionality of the web application should be directed to the user who uploaded it, as the platform provider does not assume responsibility for its maintenance or support.
+
+By continuing to utilize this web application, you are indicating your understanding and acceptance of this disclaimer.

--- a/filemappings.json
+++ b/filemappings.json
@@ -790,6 +790,11 @@
     "Fr": "/fr/_sidebar.md"
   },
   {
+    "Id": "a0e7cf8a-06af-487e-93da-ee34e8b9c060",
+    "En": "/UserGuide/Acknowledgements/WebAppTC.md",
+    "Fr": "/fr/UserGuide/Acknowledgements/WebAppTC-fr.md"
+  },
+  {
     "Id": "jf8ew9mm-10ba-m1qo-n2e4-0mans938mdn5",
     "En": "/UserGuide/Migration/Overview.md",
     "Fr": "/fr/UserGuide/Migration/Survol.md"

--- a/fr/UserGuide/Acknowledgements/WebAppTC-fr.md
+++ b/fr/UserGuide/Acknowledgements/WebAppTC-fr.md
@@ -1,0 +1,9 @@
+L'application web suivante a été téléchargée par un utilisateur sur cette plateforme de données à l'aide de son propre code. Le contenu et les fonctionnalités de cette application sont entièrement contrôlés par l'utilisateur qui l'a téléchargée, et le fournisseur de la plateforme n'est pas responsable de son contenu, de son exactitude ou de ses performances.
+
+Il est de la seule responsabilité de l'utilisateur et du créateur de contenu de s'assurer que tout matériel ou information inclus dans l'application web est conforme aux lois, réglementations et normes éthiques applicables. Le fournisseur de la plateforme n'approuve pas, ne garantit pas l'adéquation, l'exhaustivité ou la sécurité de l'application téléchargée.
+
+En accédant à cette application web et en l'utilisant, vous reconnaissez que le fournisseur de la plateforme n'assume aucune responsabilité pour les dommages, pertes ou blessures résultant de l'utilisation ou de la confiance accordée au contenu fourni par l'utilisateur. Il est conseillé aux utilisateurs de faire preuve de prudence et de diligence raisonnable lorsqu'ils interagissent avec l'application et son contenu.
+
+Veuillez noter que toute question ou préoccupation concernant le contenu ou la fonctionnalité de l'application web doit être adressée à l'utilisateur qui l'a téléchargée, étant donné que le fournisseur de la plateforme n'assume pas la responsabilité de sa maintenance ou de son soutien.
+
+En continuant à utiliser cette application web, vous indiquez que vous comprenez et acceptez cette clause de non-responsabilité.


### PR DESCRIPTION
Adding the terms for the web app to the documentation in order to use it with the new control. If this works we can add other similar acknowledgement messages (e.g. storage token generation) the same way.