### PR TITLE
Adding expiry info to terms for storage tokens

### DIFF
--- a/UserGuide/Acknowledgements/StorageTokenTC.md
+++ b/UserGuide/Acknowledgements/StorageTokenTC.md
@@ -12,3 +12,5 @@ By uploading files to the Azure Storage Blob using a provided token, you (the "U
 - Users must not upload any files that: 
   - Contain viruses, worms, Trojan horses, ransomware, or any form of malicious code. 
   - Have been intentionally designed to disrupt or compromise the integrity of our systems, other users' data, or any third-party systems. 
+
+By default, tokens expire after 30 minutes. If you require a longer expiry time, please complete a support request.

--- a/fr/UserGuide/Acknowledgements/StorageTokenTC-fr.md
+++ b/fr/UserGuide/Acknowledgements/StorageTokenTC-fr.md
@@ -12,3 +12,5 @@ En envoyant des fichiers vers Azure Storage Blob à l'aide d'un jeton fourni, vo
 - Les utilisateurs ne doivent pas envoyer de fichiers qui :  
   - Contiennent des virus, des vers, des chevaux de Troie, des rançongiciels ou toute autre forme de code malveillant  
   - Ont été intentionnellement conçus pour perturber ou compromettre l'intégrité de nos systèmes, des données des autres utilisateurs ou des systèmes de tiers. 
+
+Par défaut, les jetons expirent après 30 minutes. Si vous avez besoin d'une durée de validité plus longue, veuillez soumettre une demande de support.


### PR DESCRIPTION
This PR clarifies the expiration of tokens and directs users to submit a support request to get an extended token.

Should be merged with https://github.com/ssc-sp/datahub-portal/pull/1535