### PR TITLE
Renaming Getting Started category

### DIFF
--- a/UserGuide/_sidebar.md
+++ b/UserGuide/_sidebar.md
@@ -1,7 +1,7 @@
 - [Federal Science DataHub User Guide](/UserGuide/User-Guide.md)
 
 - Learn [](Icon:LibraryBooks)
-  - Getting Started
+  - Managing Workspaces and Users
     - [Account Registration](/UserGuide/Preregistration/Preregistration.md)
     - [Create a Workspace](/UserGuide/GettingStarted/Creating-a-workspace.md)
     - [Complete Metadata](/UserGuide/GettingStarted/Complete-metadata.md)

--- a/fr/UserGuide/_sidebar.md
+++ b/fr/UserGuide/_sidebar.md
@@ -1,7 +1,7 @@
 - [Guide de l'utilisateur du DataHub scientifique fédéral](/fr/UserGuide/Guide-de-l'utilisateur.md)
 
 - Apprendre [](Icon:LibraryBooks)
-  - Pour commencer
+  - Gestion des espaces de travail et des utilisateurs
     - [Enregistrement du compte](/fr/UserGuide/Preregistration/Preregistration.md)
     - [Créer un espace de travail](/fr/UserGuide/GettingStarted/Creating-a-workspace.md)
     - [Métadonnées complètes](/fr/UserGuide/GettingStarted/Complete-metadata.md)


### PR DESCRIPTION
This implements one of the requested changes discussed previously and renames the Getting Started category to Managing Workspaces and Users