### PR TITLE
Adding a workflow to create releases for Terms & Conditions when updated

### DIFF
--- a/.github/workflows/terms-and-conditions-release.yml
+++ b/.github/workflows/terms-and-conditions-release.yml
@@ -1,0 +1,40 @@
+name: Auto Release on Terms and Conditions Change
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - UserGuide/POC-Terms-And-Conditions.md
+      - fr/UserGuide/Conditions-générales-de-POC.md
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Make tag name
+        id: mk
+        run: |
+          TAG="v. $(date -u +%Y.%m.%d)"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.mk.outputs.tag }}
+          name: Release ${{ steps.mk.outputs.tag }}
+          body: |
+            Automated release triggered by file changes in commit ${{ github.sha }}.
+
+            **Commit message:** ${{ github.event.head_commit.message }}
+          files: |
+            UserGuide/POC-Terms-And-Conditions.md
+            fr/UserGuide/Conditions-générales-de-POC.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+ 


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate releases whenever the terms and conditions documentation is updated. This helps ensure that any changes to these key documents are tracked and released promptly.

Automation of terms and conditions release:

* Added `.github/workflows/terms-and-conditions-release.yml` to automatically create a GitHub release when either `UserGuide/POC-Terms-And-Conditions.md` or `fr/UserGuide/Conditions-générales-de-POC.md` is changed in the `main` branch.
* The workflow generates a date-based tag and includes the commit message and SHA in the release notes, attaching the updated terms files to the release.